### PR TITLE
Fixed resCreatorAccount variable in main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "aznamingtool" {
   location         = "EastUS"
   deployment_option = "container_instance"
   business_description = "AzNamingTool"
-  res_creator_account  = "John Doe"
+  creator_account  = "John Doe"
   release_env          = "DEV"
   resource_category    = "Tools"
   res_app_family       = "Cloud-Core"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "rg" {
   location = var.location
   tags = {
     "BusinessDescription" = var.business_description
-    "resCreatorAccount"   = var.res_creator_account
+    "resCreatorAccount"   = var.creator_account
     "ReleaseEnv"          = var.release_env
     "ResourceCategory"    = var.resource_category
     "resAppFamily"        = var.res_app_family


### PR DESCRIPTION
Incorrect as required input is creator_account "resCreatorAccount"   = var.res_creator_account

New corrected line. "resCreatorAccount"   = var.creator_account


Terraform deployment has been tested and works.